### PR TITLE
Dev

### DIFF
--- a/src/DPUnity.Wpf.DpTreeView/CheckBoxTreeViewBehavior.cs
+++ b/src/DPUnity.Wpf.DpTreeView/CheckBoxTreeViewBehavior.cs
@@ -71,6 +71,67 @@ namespace DPUnity.Wpf.DpTreeView
                     ScheduleUpdate(item, isChecked, getter, setter);
                 }
             };
+            // Track dynamic children changes to keep check-state propagation consistent when items are added/removed at runtime
+            node.Children.CollectionChanged += (s, e) =>
+            {
+                // Handle added children: hook behavior and align parent/ancestors state
+                if (e.NewItems != null)
+                {
+                    foreach (var obj in e.NewItems)
+                    {
+                        if (obj is T child)
+                        {
+                            // Ensure the new child has behavior wired up
+                            SetupCheckBoxBehavior(child);
+
+                            // If parent has a definite state, optionally propagate it to the new subtree
+                            var parentState = getter(node);
+                            if (parentState.HasValue)
+                            {
+                                // Avoid re-entrancy while bulk-updating new subtree
+                                LockUI();
+                                try
+                                {
+                                    UpdateChildCheckStatesBatch(child, parentState.Value, setter);
+                                }
+                                finally
+                                {
+                                    UnlockUI();
+                                }
+                            }
+
+                            // Recalculate tri-state for the parent and its ancestors now that a child exists/changed
+                            LockUI();
+                            try
+                            {
+                                UpdateNodeStateFromChildren(node, getter, setter);
+                                // Propagate upwards starting from this parent
+                                UpdateParentCheckStateOptimized(node, getter, setter);
+                            }
+                            finally
+                            {
+                                UnlockUI();
+                            }
+                        }
+                    }
+                }
+
+                // Handle removed children: recompute parent's tri-state and bubble up
+                if (e.OldItems != null)
+                {
+                    // After removal, child.Parent may be nulled already; we know 'node' is the parent
+                    LockUI();
+                    try
+                    {
+                        UpdateNodeStateFromChildren(node, getter, setter);
+                        UpdateParentCheckStateOptimized(node, getter, setter);
+                    }
+                    finally
+                    {
+                        UnlockUI();
+                    }
+                }
+            };
             foreach (var child in node.Children)
             {
                 SetupCheckBoxBehavior(child);
@@ -234,6 +295,36 @@ namespace DPUnity.Wpf.DpTreeView
                 };
                 _updateTimers[item] = timer;
                 timer.Start();
+            }
+        }
+
+        // Helper: recompute a node's IsChecked from its children's states (all true => true, all false => false, mixed => null)
+        private static void UpdateNodeStateFromChildren<T>(T node, Func<object, bool?> getter, Action<object, bool?> setter) where T : HierarchicalItemBase<T>
+        {
+            if (node.Children == null || node.Children.Count == 0)
+            {
+                return;
+            }
+
+            bool allChecked = true;
+            bool allUnchecked = true;
+            var children = node.Children;
+            for (int i = 0; i < children.Count; i++)
+            {
+                bool? state = getter(children[i]);
+                if (state != true) allChecked = false;
+                if (state != false) allUnchecked = false;
+                if (!allChecked && !allUnchecked)
+                {
+                    break;
+                }
+            }
+
+            bool? newState = allChecked ? true : allUnchecked ? false : (bool?)null;
+            bool? currentState = getter(node);
+            if (newState != currentState)
+            {
+                setter(node, newState);
             }
         }
     }

--- a/src/DPUnity.Wpf.DpTreeView/CheckBoxTreeViewBehavior.cs
+++ b/src/DPUnity.Wpf.DpTreeView/CheckBoxTreeViewBehavior.cs
@@ -3,7 +3,6 @@ using System.ComponentModel;
 using System.Reflection;
 using System.Windows.Input;
 using System.Windows.Threading;
-
 namespace DPUnity.Wpf.DpTreeView
 {
     /// <summary>
@@ -12,21 +11,17 @@ namespace DPUnity.Wpf.DpTreeView
     public static class CheckBoxBehavior
     {
         // Cache for reflection delegates to improve performance
-        private static readonly Dictionary<Type, Func<object, bool?>> _getterCache = [];
-        private static readonly Dictionary<Type, Action<object, bool?>> _setterCache = [];
-
+        private static readonly Dictionary<Type, Func<object, bool?>> _getterCache = new();
+        private static readonly Dictionary<Type, Action<object, bool?>> _setterCache = new();
         // Add these fields to the CheckBoxBehavior class
-        private static readonly Dictionary<object, System.Timers.Timer> _updateTimers = [];
+        private static readonly Dictionary<object, System.Timers.Timer> _updateTimers = new();
         private static readonly object _timerLock = new();
-
         // Add UI locking mechanism
         private static readonly object _uiLockObj = new();
         private static bool _isUpdating = false;
         private static int _updateCounter = 0;
-
         // UI thread dispatcher
         private static Dispatcher? _uiDispatcher;
-
         private static Func<object, bool?> GetIsCheckedGetter<T>() where T : HierarchicalItemBase<T>
         {
             // Existing implementation
@@ -40,7 +35,6 @@ namespace DPUnity.Wpf.DpTreeView
             }
             return getter;
         }
-
         private static Action<object, bool?> GetIsCheckedSetter<T>() where T : HierarchicalItemBase<T>
         {
             // Existing implementation
@@ -54,7 +48,6 @@ namespace DPUnity.Wpf.DpTreeView
             }
             return setter;
         }
-
         /// <summary>
         /// Sets up the hierarchical checkbox behavior for a node and its descendants
         /// </summary>
@@ -62,10 +55,8 @@ namespace DPUnity.Wpf.DpTreeView
         {
             // Store UI Dispatcher on first call
             _uiDispatcher ??= Dispatcher.CurrentDispatcher;
-
             var getter = GetIsCheckedGetter<T>();
             var setter = GetIsCheckedSetter<T>();
-
             node.PropertyChanged += (sender, e) =>
             {
                 if (e.PropertyName == "IsChecked" && sender is T item)
@@ -75,20 +66,16 @@ namespace DPUnity.Wpf.DpTreeView
                         // Ignore changes while updating
                         return;
                     }
-
                     bool? isChecked = getter(item);
-
                     // Schedule update with throttling (50ms delay)
                     ScheduleUpdate(item, isChecked, getter, setter);
                 }
             };
-
             foreach (var child in node.Children)
             {
                 SetupCheckBoxBehavior(child);
             }
         }
-
         /// <summary>
         /// Sets up the hierarchical checkbox behavior for a collection of nodes
         /// </summary>
@@ -99,10 +86,8 @@ namespace DPUnity.Wpf.DpTreeView
                 SetupCheckBoxBehavior(node);
             }
         }
-
         // Flag to prevent redundant updates
         private static bool _updatingFromParent = false;
-
         private static void LockUI()
         {
             lock (_uiLockObj)
@@ -118,7 +103,6 @@ namespace DPUnity.Wpf.DpTreeView
                 }
             }
         }
-
         private static void UnlockUI()
         {
             lock (_uiLockObj)
@@ -134,42 +118,39 @@ namespace DPUnity.Wpf.DpTreeView
                 }
             }
         }
-
         private static void UpdateChildCheckStatesBatch<T>(T parent, bool isChecked, Action<object, bool?> setter) where T : HierarchicalItemBase<T>
         {
             try
             {
                 _updatingFromParent = true;
-
-                // Use queue instead of recursion to prevent stack overflow on large trees
-                Queue<T> nodesToProcess = new();
-                foreach (var child in parent.Children)
+                // Use Stack<T> for DFS traversal to minimize memory usage (max stack size ~ tree depth, better than BFS queue size ~ tree width/subtree size)
+                Stack<T> nodesToProcess = new Stack<T>();
+                // Push all immediate children (order doesn't matter for setting states, but reverse to simulate typical recursion order if needed)
+                for (int i = parent.Children.Count - 1; i >= 0; i--)
                 {
-                    nodesToProcess.Enqueue(child);
+                    nodesToProcess.Push(parent.Children[i]);
                 }
-
                 while (nodesToProcess.Count > 0)
                 {
-                    T current = nodesToProcess.Dequeue();
+                    T current = nodesToProcess.Pop();
                     setter(current, isChecked);
-
-                    foreach (var childOfChild in current.Children)
+                    // Push children in reverse order
+                    for (int i = current.Children.Count - 1; i >= 0; i--)
                     {
-                        nodesToProcess.Enqueue(childOfChild);
+                        nodesToProcess.Push(current.Children[i]);
                     }
                 }
+                // No need to clear stack; it's local and will be GC'ed after method exit
             }
             finally
             {
                 _updatingFromParent = false;
             }
         }
-
         private static void UpdateParentCheckStateOptimized<T>(T node, Func<object, bool?> getter, Action<object, bool?> setter) where T : HierarchicalItemBase<T>
         {
             // Existing implementation
             T? currentNode = node.Parent;
-
             while (currentNode != null)
             {
                 if (!currentNode.Children.Any())
@@ -177,30 +158,24 @@ namespace DPUnity.Wpf.DpTreeView
                     currentNode = currentNode.Parent;
                     continue;
                 }
-
                 bool allChecked = true;
                 bool allUnchecked = true;
                 bool shouldBreak = false;
-
                 // Use for loop instead of foreach for better performance
                 var children = currentNode.Children;
                 for (int i = 0; i < children.Count; i++)
                 {
                     bool? siblingState = getter(children[i]);
-
                     if (siblingState != true) allChecked = false;
                     if (siblingState != false) allUnchecked = false;
-
                     if (!allChecked && !allUnchecked)
                     {
                         shouldBreak = true;
                         break;
                     }
                 }
-
                 bool? newState = allChecked ? true : allUnchecked ? false : null;
                 bool? currentState = getter(currentNode);
-
                 if (newState != currentState)
                 {
                     setter(currentNode, newState);
@@ -209,58 +184,55 @@ namespace DPUnity.Wpf.DpTreeView
                 {
                     break;
                 }
-
                 currentNode = currentNode.Parent;
             }
         }
-
         private static void ScheduleUpdate<T>(T item, bool? isChecked, Func<object, bool?> getter, Action<object, bool?> setter)
             where T : HierarchicalItemBase<T>, INotifyPropertyChanged
         {
             LockUI(); // Lock UI before starting the update process
-
             lock (_timerLock)
             {
-                if (_updateTimers.TryGetValue(item as object, out var existingTimer))
+                if (_updateTimers.TryGetValue(item, out var existingTimer))
                 {
                     existingTimer.Stop();
                     existingTimer.Dispose();
                 }
-
                 var timer = new System.Timers.Timer(50)
                 {
                     AutoReset = false
                 };
-                timer.Elapsed += async (s, e) =>
+                timer.Elapsed += (s, e) =>
                 {
-                    try
+                    // Dispatch the update to the UI thread to avoid cross-thread issues with property changes and bindings
+                    _uiDispatcher?.Invoke(() =>
                     {
-                        if (isChecked != null)
+                        try
                         {
-                            UpdateChildCheckStatesBatch(item, isChecked.Value, setter);
+                            if (isChecked.HasValue)
+                            {
+                                UpdateChildCheckStatesBatch(item, isChecked.Value, setter);
+                            }
+                            if (!_updatingFromParent)
+                            {
+                                UpdateParentCheckStateOptimized(item, getter, setter);
+                            }
+                            // Optional: Force GC for testing memory release (comment out in production; .NET GC handles it automatically)
+                            // GC.Collect();
+                            // GC.WaitForPendingFinalizers();
                         }
-
-                        if (!_updatingFromParent)
+                        finally
                         {
-                            UpdateParentCheckStateOptimized(item, getter, setter);
+                            lock (_timerLock)
+                            {
+                                _updateTimers.Remove(item);
+                                timer.Dispose();
+                            }
+                            UnlockUI(); // Unlock UI after all updates are complete
                         }
-
-                        // Add delay to ensure UI refreshes properly
-                        await Task.Delay(10);
-                    }
-                    finally
-                    {
-                        lock (_timerLock)
-                        {
-                            _updateTimers.Remove(item as object);
-                            timer.Dispose();
-                        }
-
-                        UnlockUI(); // Unlock UI after all updates are complete
-                    }
+                    });
                 };
-
-                _updateTimers[item as object] = timer;
+                _updateTimers[item] = timer;
                 timer.Start();
             }
         }

--- a/src/DPUnity.Wpf.DpTreeView/DPUnity.Wpf.DpTreeView.csproj
+++ b/src/DPUnity.Wpf.DpTreeView/DPUnity.Wpf.DpTreeView.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageId>DPUnity.Wpf.DpTreeView</PackageId>
     <Title>DPUnity WPF TreeView</Title>
     <Description>Enhanced TreeView controls with filtering and hierarchical data support for WPF applications</Description>

--- a/src/DPUnity.Wpf.DpTreeView/FilterTreeViews/CheckIconFilterTreeView.xaml
+++ b/src/DPUnity.Wpf.DpTreeView/FilterTreeViews/CheckIconFilterTreeView.xaml
@@ -5,7 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:DPUnity.Wpf.DpTreeView.FilterTreeViews"
              xmlns:hc="https://handyorg.github.io/handycontrol"
-             xmlns:ftv="clr-namespace:DPUnity.Wpf.FilterTreeView"
+             xmlns:ftv="clr-namespace:DPUnity.Wpf.DpTreeView"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
     <Grid>
@@ -13,9 +13,11 @@
             <ColumnDefinition Width="205" />
             <ColumnDefinition />
         </Grid.ColumnDefinitions>
-        <hc:CheckTreeView Style="{DynamicResource DP_TreeViewContainIcon}"
-                          Grid.ColumnSpan="2"
-                          ItemsSource="{Binding ItemsSource, RelativeSource={RelativeSource AncestorType=UserControl}}" />
+    <hc:CheckTreeView Style="{DynamicResource DP_TreeViewContainIcon}"
+              Grid.ColumnSpan="2"
+              ftv:TreeViewBehavior.IsBehaviorEnabled="True"
+              ftv:TreeViewBehavior.ItemsSourceWatcher="{Binding ItemsSource, RelativeSource={RelativeSource AncestorType=UserControl}}"
+              ItemsSource="{Binding ItemsSource, RelativeSource={RelativeSource AncestorType=UserControl}}" />
         <hc:TextBox hc:InfoElement.Placeholder="Search"
                     Margin="5 9 10 0"
                     Grid.Column="1"

--- a/src/DPUnity.Wpf.DpTreeView/TreeViewStyle.xaml
+++ b/src/DPUnity.Wpf.DpTreeView/TreeViewStyle.xaml
@@ -205,8 +205,8 @@
                                            Margin="5 0" />
                                 <ComboBox x:Name="ExpandLevelComboBox"
                                           Height="25"
-                                          ItemsSource="{Binding (ftv:TreeViewBehavior.ExpandLevels), RelativeSource={RelativeSource AncestorType=TreeView}}"
-                                          SelectedItem="{Binding (ftv:TreeViewBehavior.SelectedExpandLevel), RelativeSource={RelativeSource AncestorType=TreeView}, Mode=TwoWay}" />
+                                          ItemsSource="{Binding (ftv:TreeViewBehavior.ExpandLevels), RelativeSource={RelativeSource TemplatedParent}}"
+                                          SelectedItem="{Binding (ftv:TreeViewBehavior.SelectedExpandLevel), RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}" />
                                 <hc:Divider Orientation="Vertical" />
                             </hc:SimpleStackPanel>
                         </Border>


### PR DESCRIPTION
This pull request introduces improvements to the hierarchical checkbox behavior in tree views, specifically targeting dynamic updates when tree structure changes and optimizing state propagation. The main changes enhance the robustness and performance of check-state synchronization, especially when items are added or removed at runtime. Additionally, there are minor fixes to XAML bindings and a version bump.

**TreeView Checkbox Behavior Enhancements:**

* Added logic to automatically track and handle dynamic changes to tree node children, ensuring that check-state propagation and tri-state recalculation remain consistent when items are added or removed at runtime. This includes wiring up new children and updating parent/ancestor states accordingly.
* Refactored the batch updating of child check states to use a stack-based depth-first traversal instead of a queue, reducing memory usage and avoiding stack overflow for large trees.
* Improved the scheduling and execution of check-state updates by ensuring updates run on the UI thread and by cleaning up timer management, which helps prevent cross-thread issues and resource leaks.
* Added a helper method to recompute a node's check state based on its children's states, supporting proper tri-state logic (checked, unchecked, indeterminate) after dynamic changes.

**XAML and Project Metadata Fixes:**

* Fixed XAML namespace and binding issues in `CheckIconFilterTreeView.xaml` and `TreeViewStyle.xaml` to ensure correct behavior and data binding for tree view controls. [[1]](diffhunk://#diff-87377b83a261263f93fe9339ca62d9e8232eafd98a8e4e6527757686881d8dbaL8-R8) [[2]](diffhunk://#diff-87377b83a261263f93fe9339ca62d9e8232eafd98a8e4e6527757686881d8dbaR18-R19) [[3]](diffhunk://#diff-606b3722b7ee7dc1d00e530787547c52fc6f6d0586ca7a9fff6b29c09c66a83bL208-R209)
* Updated project version to `1.0.2` in the `.csproj` file.