### PR TITLE
Remove GC code and update project dependencies

### DIFF
--- a/src/DPUnity.Wpf.DpTreeView/CheckBoxTreeViewBehavior.cs
+++ b/src/DPUnity.Wpf.DpTreeView/CheckBoxTreeViewBehavior.cs
@@ -278,9 +278,6 @@ namespace DPUnity.Wpf.DpTreeView
                             {
                                 UpdateParentCheckStateOptimized(item, getter, setter);
                             }
-                            // Optional: Force GC for testing memory release (comment out in production; .NET GC handles it automatically)
-                            // GC.Collect();
-                            // GC.WaitForPendingFinalizers();
                         }
                         finally
                         {

--- a/src/DPUnity.Wpf.DpTreeView/DPUnity.Wpf.DpTreeView.csproj
+++ b/src/DPUnity.Wpf.DpTreeView/DPUnity.Wpf.DpTreeView.csproj
@@ -1,23 +1,32 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
-    <Nullable>enable</Nullable>
-    <UseWPF>true</UseWPF>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Version>1.0.2</Version>
-    <PackageId>DPUnity.Wpf.DpTreeView</PackageId>
-    <Title>DPUnity WPF TreeView</Title>
-    <Description>Enhanced TreeView controls with filtering and hierarchical data support for WPF applications</Description>
-    <Authors>vanlk</Authors>
-    <Company>DPUnity</Company>
-    <RepositoryUrl>https://github.com/namdpu/DPUnity.Wpf.TreeView</RepositoryUrl>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net8.0-windows</TargetFramework>
+		<Nullable>enable</Nullable>
+		<UseWPF>true</UseWPF>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Version>1.0.3</Version>
+		<PackageId>DPUnity.Wpf.DpTreeView</PackageId>
+		<Title>DPUnity WPF TreeView</Title>
+		<Description>Enhanced TreeView controls with filtering and hierarchical data support for WPF applications</Description>
+		<Authors>vanlk</Authors>
+		<Company>DPUnity</Company>
+		<RepositoryUrl>https://github.com/namdpu/DPUnity.Wpf.TreeView</RepositoryUrl>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-    <PackageReference Include="DPUnity.Windows" Version="1.1.8" />
-    <PackageReference Include="DPUnity.Wpf.UI" Version="1.0.8.2-preview-6" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+		<PackageReference Include="DPUnity.Windows" Version="1.1.8" />
+		<PackageReference Include="DPUnity.Wpf.UI" Version="1.0.8.4" />
+		<PackageReference Include="HandyControls" Version="3.6.0" />
+	</ItemGroup>
+
+
+	<!--<ItemGroup>
+		<Reference Include="DPUnity.Wpf.UI">
+			<HintPath>..\..\..\DPUnity.Wpf.UI\bin\Debug\net8.0-windows\DPUnity.Wpf.UI.dll</HintPath>
+		</Reference>
+	</ItemGroup>-->
+
 
 </Project>


### PR DESCRIPTION
This pull request updates the `DPUnity.Wpf.DpTreeView` project with dependency and version improvements, as well as a minor cleanup in the checkbox tree view behavior code. The most notable changes involve updating package references and the project version, along with the addition of a new UI library.

**Project configuration and dependency updates:**

* Updated the project version in `DPUnity.Wpf.DpTreeView.csproj` from `1.0.2` to `1.0.3` to reflect new changes.
* Upgraded the `DPUnity.Wpf.UI` package reference to version `1.0.8.4` and added a new dependency on `HandyControls` version `3.6.0` in the project file, improving UI capabilities.

**Code cleanup:**

* Removed commented-out forced garbage collection calls from `CheckBoxTreeViewBehavior.cs`, ensuring cleaner production code and relying on .NET's automatic memory management.Removed unnecessary commented-out garbage collection code from `CheckBoxTreeViewBehavior.cs`. Updated `DpTreeView.csproj` to version `1.0.3` and added a new `<ItemGroup>` with package references for `CommunityToolkit.Mvvm`, `DPUnity.Windows`, `DPUnity.Wpf.UI`, and `HandyControls`. The previous package references have been removed, and a commented-out reference to `DPUnity.Wpf.UI` has been included.