### PR TITLE
Update project file and dependencies for DpTreeView

### DIFF
--- a/src/DPUnity.Wpf.DpTreeView/DPUnity.Wpf.DpTreeView.csproj
+++ b/src/DPUnity.Wpf.DpTreeView/DPUnity.Wpf.DpTreeView.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFrameworks>net8.0-windows</TargetFrameworks>
 		<Nullable>enable</Nullable>
 		<UseWPF>true</UseWPF>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>1.0.5</Version>
+		<Version>1.0.6</Version>
 		<PackageId>DPUnity.Wpf.DpTreeView</PackageId>
 		<Title>DPUnity WPF TreeView</Title>
 		<Description>Enhanced TreeView controls with filtering and hierarchical data support for WPF applications</Description>
@@ -16,8 +16,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-		<PackageReference Include="DPUnity.Windows" Version="1.1.8" />
-		<PackageReference Include="DPUnity.Wpf.UI" Version="1.0.8.6" />
+		<PackageReference Include="DPUnity.Wpf.UI" Version="1.0.9" />
 		<PackageReference Include="HandyControls" Version="3.6.0" />
 	</ItemGroup>
 


### PR DESCRIPTION
This pull request updates the `DPUnity.Wpf.DpTreeView` project with a new version and refines its dependencies. The main changes focus on versioning and package management.

Versioning and framework update:

* Bumped the project version from `1.0.5` to `1.0.6` in the `DPUnity.Wpf.DpTreeView.csproj` file.
* Changed the `TargetFramework` property to `TargetFrameworks` to allow for future multi-targeting flexibility, though currently only `net8.0-windows` is specified.

Dependency management:

* Updated the `DPUnity.Wpf.UI` package reference to version `1.0.9` and removed the `DPUnity.Windows` package reference, streamlining the dependencies for the project.- Changed target framework to support multiple frameworks.
- Incremented version from 1.0.5 to 1.0.6.
- Updated DPUnity.Wpf.UI package to version 1.0.9.
- Removed DPUnity.Windows package reference.