### PR TITLE
Update version and button styles in TreeView

### DIFF
--- a/src/DPUnity.Wpf.DpTreeView/DPUnity.Wpf.DpTreeView.csproj
+++ b/src/DPUnity.Wpf.DpTreeView/DPUnity.Wpf.DpTreeView.csproj
@@ -6,7 +6,7 @@
 		<LangVersion>latest</LangVersion>
 		<UseWPF>true</UseWPF>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>1.0.7</Version>
+		<Version>1.0.8</Version>
 		<PackageId>DPUnity.Wpf.DpTreeView</PackageId>
 		<Title>DPUnity WPF TreeView</Title>
 		<Description>Enhanced TreeView controls with filtering and hierarchical data support for WPF applications</Description>
@@ -17,7 +17,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-		<PackageReference Include="DPUnity.Wpf.UI" Version="1.0.9" />
+		<PackageReference Include="DPUnity.Wpf.UI" Version="1.0.11" />
 		<PackageReference Include="HandyControls" Version="3.6.0" />
 	</ItemGroup>
 

--- a/src/DPUnity.Wpf.DpTreeView/TreeViewStyle.xaml
+++ b/src/DPUnity.Wpf.DpTreeView/TreeViewStyle.xaml
@@ -189,12 +189,12 @@
                             <hc:SimpleStackPanel Height="35"
                                                  Margin="5"
                                                  Orientation="Horizontal">
-                                <Button Style="{DynamicResource DP_IconButton}"
+                                <Button Style="{DynamicResource DP_IconButtonWithoutBorder}"
                                         Content="ExpandAll"
                                         ToolTip="Expand All"
                                         Command="{Binding (ftv:TreeViewBehavior.ExpandAllCommand), RelativeSource={RelativeSource AncestorType=TreeView}}"
                                         CommandParameter="{Binding RelativeSource={RelativeSource AncestorType=TreeView}}" />
-                                <Button Style="{DynamicResource DP_IconButton}"
+                                <Button Style="{DynamicResource DP_IconButtonWithoutBorder}"
                                         Content="CollapseAll"
                                         ToolTip="Collapse All"
                                         Command="{Binding (ftv:TreeViewBehavior.CollapseAllCommand), RelativeSource={RelativeSource AncestorType=TreeView}}"


### PR DESCRIPTION
This pull request updates the `DPUnity.Wpf.DpTreeView` package to improve UI consistency and ensure compatibility with dependencies. The most important changes include updating the package version, upgrading a key dependency, and refining button styles in the TreeView UI.

Dependency and version updates:
* Bumped the `DPUnity.Wpf.DpTreeView` package version from `1.0.7` to `1.0.8` in `DPUnity.Wpf.DpTreeView.csproj` to reflect the latest changes.
* Upgraded the `DPUnity.Wpf.UI` dependency from version `1.0.9` to `1.0.11` in `DPUnity.Wpf.DpTreeView.csproj` for improved compatibility and features.

UI improvements:
* Changed the style of the "Expand All" and "Collapse All" buttons in `TreeViewStyle.xaml` from `DP_IconButton` to `DP_IconButtonWithoutBorder` for a cleaner look without borders.- Bump project version from 1.0.7 to 1.0.8.
- Update `DPUnity.Wpf.UI` dependency from 1.0.9 to 1.0.11.
- Change button styles for "ExpandAll" and "CollapseAll" from `DP_IconButton` to `DP_IconButtonWithoutBorder` in `TreeViewStyle.xaml` to enhance visual appearance.