### PR TITLE
Dev

### DIFF
--- a/src/DPUnity.Wpf.DpTreeView/DPUnity.Wpf.DpTreeView.csproj
+++ b/src/DPUnity.Wpf.DpTreeView/DPUnity.Wpf.DpTreeView.csproj
@@ -6,7 +6,7 @@
 		<LangVersion>latest</LangVersion>
 		<UseWPF>true</UseWPF>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>1.0.9</Version>
+		<Version>1.0.10</Version>
 		<PackageId>DPUnity.Wpf.DpTreeView</PackageId>
 		<Title>DPUnity WPF TreeView</Title>
 		<Description>Enhanced TreeView controls with filtering and hierarchical data support for WPF applications</Description>
@@ -17,16 +17,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-		<PackageReference Include="DPUnity.Wpf.UI" Version="1.0.15" />
+		<PackageReference Include="DPUnity.Wpf.UI" Version="1.0.29" />
 		<PackageReference Include="HandyControls" Version="3.6.0" />
 	</ItemGroup>
-
-
-	<!--<ItemGroup>
-		<Reference Include="DPUnity.Wpf.UI">
-			<HintPath>..\..\..\DPUnity.Wpf.UI\bin\Debug\net8.0-windows\DPUnity.Wpf.UI.dll</HintPath>
-		</Reference>
-	</ItemGroup>-->
-
-
 </Project>

--- a/src/DPUnity.Wpf.DpTreeView/DPUnity.Wpf.DpTreeView.csproj
+++ b/src/DPUnity.Wpf.DpTreeView/DPUnity.Wpf.DpTreeView.csproj
@@ -17,7 +17,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-		<PackageReference Include="DPUnity.Wpf.UI" Version="1.0.11" />
+		<PackageReference Include="DPUnity.Wpf.UI" Version="1.0.15" />
 		<PackageReference Include="HandyControls" Version="3.6.0" />
 	</ItemGroup>
 

--- a/src/DPUnity.Wpf.DpTreeView/DPUnity.Wpf.DpTreeView.csproj
+++ b/src/DPUnity.Wpf.DpTreeView/DPUnity.Wpf.DpTreeView.csproj
@@ -6,7 +6,7 @@
 		<LangVersion>latest</LangVersion>
 		<UseWPF>true</UseWPF>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>1.0.8</Version>
+		<Version>1.0.9</Version>
 		<PackageId>DPUnity.Wpf.DpTreeView</PackageId>
 		<Title>DPUnity WPF TreeView</Title>
 		<Description>Enhanced TreeView controls with filtering and hierarchical data support for WPF applications</Description>

--- a/src/DPUnity.Wpf.DpTreeView/FilterTreeViews/CheckIconFilterTreeView.xaml
+++ b/src/DPUnity.Wpf.DpTreeView/FilterTreeViews/CheckIconFilterTreeView.xaml
@@ -1,30 +1,31 @@
 ﻿<UserControl x:Class="DPUnity.Wpf.DpTreeView.FilterTreeViews.CheckIconFilterTreeView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="clr-namespace:DPUnity.Wpf.DpTreeView.FilterTreeViews"
              xmlns:hc="https://handyorg.github.io/handycontrol"
              xmlns:ftv="clr-namespace:DPUnity.Wpf.DpTreeView"
-             mc:Ignorable="d" 
-             d:DesignHeight="450" d:DesignWidth="800">
+             mc:Ignorable="d"
+             d:DesignHeight="450"
+             d:DesignWidth="800">
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="205" />
             <ColumnDefinition />
         </Grid.ColumnDefinitions>
-    <hc:CheckTreeView Style="{DynamicResource DP_TreeViewContainIcon}"
-              Grid.ColumnSpan="2"
-              ftv:TreeViewBehavior.IsBehaviorEnabled="True"
-              ftv:TreeViewBehavior.ItemsSourceWatcher="{Binding ItemsSource, RelativeSource={RelativeSource AncestorType=UserControl}}"
-              ItemsSource="{Binding ItemsSource, RelativeSource={RelativeSource AncestorType=UserControl}}" />
+        <hc:CheckTreeView Style="{DynamicResource DP_TreeViewContainIcon}"
+                          Grid.ColumnSpan="2"
+                          ftv:TreeViewBehavior.IsBehaviorEnabled="True"
+                          ftv:TreeViewBehavior.ItemsSourceWatcher="{Binding ItemsSource, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                          ItemsSource="{Binding ItemsSource, RelativeSource={RelativeSource AncestorType=UserControl}}" />
         <hc:TextBox hc:InfoElement.Placeholder="Tìm kiếm"
-                    Margin="5 9 10 0"
+                      hc:InfoElement.ShowClearButton="True"
+                    Margin="5 5 10 0"
                     Grid.Column="1"
-                    Height="30"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Top"
-                    Style="{DynamicResource TextBoxExtend}"
+                 Style="{DynamicResource TextBoxPlusBaseStyle}"
                     Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}" />
     </Grid>
 </UserControl>

--- a/src/DPUnity.Wpf.DpTreeView/FilterTreeViews/CheckIconFilterTreeView.xaml
+++ b/src/DPUnity.Wpf.DpTreeView/FilterTreeViews/CheckIconFilterTreeView.xaml
@@ -18,12 +18,13 @@
               ftv:TreeViewBehavior.IsBehaviorEnabled="True"
               ftv:TreeViewBehavior.ItemsSourceWatcher="{Binding ItemsSource, RelativeSource={RelativeSource AncestorType=UserControl}}"
               ItemsSource="{Binding ItemsSource, RelativeSource={RelativeSource AncestorType=UserControl}}" />
-        <hc:TextBox hc:InfoElement.Placeholder="Search"
+        <hc:TextBox hc:InfoElement.Placeholder="Tìm kiếm"
                     Margin="5 9 10 0"
                     Grid.Column="1"
                     Height="30"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Top"
+                    Style="{DynamicResource TextBoxExtend}"
                     Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}" />
     </Grid>
 </UserControl>

--- a/src/DPUnity.Wpf.DpTreeView/FilterTreeViews/FilterTreeView.xaml
+++ b/src/DPUnity.Wpf.DpTreeView/FilterTreeViews/FilterTreeView.xaml
@@ -18,9 +18,10 @@
                   Grid.ColumnSpan="2"
                   ItemsSource="{Binding ItemsSource, RelativeSource={RelativeSource AncestorType=UserControl}}"
                   Margin=" 0 0 0 20" />
-        <hc:TextBox hc:InfoElement.Placeholder="Search"
+        <hc:TextBox hc:InfoElement.Placeholder="Tìm kiếm"
                     Margin="5 9 10 0"
                     Grid.Column="1"
+                    Style="{DynamicResource TextBoxExtend}"
                     Height="30"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Top"

--- a/src/DPUnity.Wpf.DpTreeView/FilterTreeViews/FilterTreeView.xaml
+++ b/src/DPUnity.Wpf.DpTreeView/FilterTreeViews/FilterTreeView.xaml
@@ -1,13 +1,14 @@
 ﻿<UserControl x:Class="DPUnity.Wpf.DpTreeView.FilterTreeViews.FilterTreeView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="clr-namespace:DPUnity.Wpf.DpTreeView.FilterTreeViews"
              xmlns:hc="https://handyorg.github.io/handycontrol"
              xmlns:ftv="clr-namespace:DPUnity.Wpf.DpTreeView"
-             mc:Ignorable="d" 
-             d:DesignHeight="450" d:DesignWidth="800">
+             mc:Ignorable="d"
+             d:DesignHeight="450"
+             d:DesignWidth="800">
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="205" />
@@ -19,12 +20,12 @@
                   ItemsSource="{Binding ItemsSource, RelativeSource={RelativeSource AncestorType=UserControl}}"
                   Margin=" 0 0 0 20" />
         <hc:TextBox hc:InfoElement.Placeholder="Tìm kiếm"
-                    Margin="5 9 10 0"
+                    hc:InfoElement.ShowClearButton="True"
+                    Margin="5 5 10 0"
                     Grid.Column="1"
-                    Style="{DynamicResource TextBoxExtend}"
-                    Height="30"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Top"
+                    Style="{DynamicResource TextBoxPlusBaseStyle}"
                     Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}" />
     </Grid>
 </UserControl>

--- a/src/DPUnity.Wpf.DpTreeView/TreeViewStyle.xaml
+++ b/src/DPUnity.Wpf.DpTreeView/TreeViewStyle.xaml
@@ -5,6 +5,7 @@
                     xmlns:ftv="clr-namespace:DPUnity.Wpf.DpTreeView">
     <ResourceDictionary.MergedDictionaries>
         <hc:IntellisenseResources Source="/HandyControl;Component/DesignTime/DesignTimeResources.xaml" />
+        <hc:Theme />
     </ResourceDictionary.MergedDictionaries>
 
 

--- a/src/DPUnity.Wpf.DpTreeView/TreeViewStyle.xaml
+++ b/src/DPUnity.Wpf.DpTreeView/TreeViewStyle.xaml
@@ -2,10 +2,11 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:hc="https://handyorg.github.io/handycontrol"
                     xmlns:icons="https://dpunity.com/dev/wpf/ui/controls/packicon"
-                    xmlns:ftv="clr-namespace:DPUnity.Wpf.DpTreeView">
+                    xmlns:ftv="clr-namespace:DPUnity.Wpf.DpTreeView"
+                    xmlns:rs="clr-namespace:DPUnity.Wpf.UI.Styles;assembly=DPUnity.Wpf.UI">
     <ResourceDictionary.MergedDictionaries>
         <hc:IntellisenseResources Source="/HandyControl;Component/DesignTime/DesignTimeResources.xaml" />
-        <hc:Theme />
+        <rs:DpuResources />
     </ResourceDictionary.MergedDictionaries>
 
 
@@ -200,6 +201,7 @@
                                         CommandParameter="{Binding RelativeSource={RelativeSource AncestorType=TreeView}}" />
                                 <hc:Divider Orientation="Vertical" />
                                 <TextBlock Text="Expand level: "
+                                           Foreground="{DynamicResource PrimaryTextBrush}"
                                            VerticalAlignment="Center"
                                            Margin="5 0" />
                                 <ComboBox x:Name="ExpandLevelComboBox"

--- a/src/DPUnity.Wpf.DpTreeView/TreeViewStyle.xaml
+++ b/src/DPUnity.Wpf.DpTreeView/TreeViewStyle.xaml
@@ -117,8 +117,6 @@
         </Setter>
     </Style>
 
-
-
     <Style x:Key="DP_HighlightTextBlockStyle"
            TargetType="hc:HighlightTextBlock">
         <Setter Property="Foreground"
@@ -187,7 +185,7 @@
                         <Border Grid.Row="0"
                                 BorderBrush="{DynamicResource BorderBrush}"
                                 BorderThickness="1">
-                            <hc:SimpleStackPanel Height="35"
+                            <hc:SimpleStackPanel 
                                                  Margin="5"
                                                  Orientation="Horizontal">
                                 <Button Style="{DynamicResource DP_IconButtonWithoutBorder}"
@@ -205,7 +203,7 @@
                                            VerticalAlignment="Center"
                                            Margin="5 0" />
                                 <ComboBox x:Name="ExpandLevelComboBox"
-                                          Height="25"
+                                          Style="{DynamicResource ComboBox.Small}"
                                           ItemsSource="{Binding (ftv:TreeViewBehavior.ExpandLevels), RelativeSource={RelativeSource TemplatedParent}}"
                                           SelectedItem="{Binding (ftv:TreeViewBehavior.SelectedExpandLevel), RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}" />
                                 <hc:Divider Orientation="Vertical" />
@@ -235,7 +233,7 @@
         <Setter Property="ItemTemplate">
             <Setter.Value>
                 <HierarchicalDataTemplate ItemsSource="{Binding Children}">
-                    <StackPanel Orientation="Horizontal">
+                    <StackPanel Orientation="Horizontal" >
                         <CheckBox IsChecked="{Binding IsChecked, Mode=TwoWay}"
                                   VerticalAlignment="Center"
                                   HorizontalAlignment="Left">
@@ -250,7 +248,7 @@
                                         <icons:PackIcon x:Name="icon"
                                                         Width="16"
                                                         Height="16"
-                                                        Margin="-3 0 0 0">
+                                                        Margin="-4 0 0 0">
                                         </icons:PackIcon>
                                     </Border>
                                     <ControlTemplate.Triggers>


### PR DESCRIPTION
This pull request updates the `DPUnity.Wpf.DpTreeView` package and refines the UI and styling for its TreeView controls. The main changes include upgrading package dependencies, improving the search/filter text box experience, and enhancing styling consistency by leveraging shared resources and adjusting control appearances.

**Dependency and Resource Updates**
* Upgraded `DPUnity.Wpf.DpTreeView` package version to `1.0.10` and updated the `DPUnity.Wpf.UI` dependency to `1.0.29` in `DPUnity.Wpf.DpTreeView.csproj`. [[1]](diffhunk://#diff-e58be18445fc02ac8fc15bb3d1407baad5ec8ef77043ed5f9a841277e8bb928cL9-R9) [[2]](diffhunk://#diff-e58be18445fc02ac8fc15bb3d1407baad5ec8ef77043ed5f9a841277e8bb928cL20-L31)
* Merged the `DpuResources` resource dictionary from `DPUnity.Wpf.UI` for consistent styling and added the `rs` namespace in `TreeViewStyle.xaml`.

**UI/UX Improvements**
* Changed the search box placeholder text from "Search" to "Tìm kiếm", enabled the clear button, adjusted margins, applied a shared style, and removed explicit height for a more native look in both `CheckIconFilterTreeView.xaml` and `FilterTreeView.xaml`. [[1]](diffhunk://#diff-87377b83a261263f93fe9339ca62d9e8232eafd98a8e4e6527757686881d8dbaL21-R28) [[2]](diffhunk://#diff-5c05241b282aadc69a87d4d2e7656c6fa7cb067a49f14a082699a382c4893254L21-R28)
* Applied additional styling improvements: added foreground color for the "Expand level" label, switched the ComboBox to use a smaller style, and tweaked icon margins for better alignment in `TreeViewStyle.xaml`. [[1]](diffhunk://#diff-606b3722b7ee7dc1d00e530787547c52fc6f6d0586ca7a9fff6b29c09c66a83bR204-R208) [[2]](diffhunk://#diff-606b3722b7ee7dc1d00e530787547c52fc6f6d0586ca7a9fff6b29c09c66a83bL252-R253)

**Minor Layout and Formatting**
* Minor formatting adjustments in XAML files, such as separating design attributes onto individual lines and removing unused code/comments for clarity. [[1]](diffhunk://#diff-87377b83a261263f93fe9339ca62d9e8232eafd98a8e4e6527757686881d8dbaL10-R11) [[2]](diffhunk://#diff-5c05241b282aadc69a87d4d2e7656c6fa7cb067a49f14a082699a382c4893254L10-R11) [[3]](diffhunk://#diff-606b3722b7ee7dc1d00e530787547c52fc6f6d0586ca7a9fff6b29c09c66a83bL119-L120) [[4]](diffhunk://#diff-606b3722b7ee7dc1d00e530787547c52fc6f6d0586ca7a9fff6b29c09c66a83bL189-R189)